### PR TITLE
[ci skip] Tweak Markdown formatting for developer's guide

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,9 +1,9 @@
 
 > **This guide will teach you:**
-> How to compile your own copy of Metabase
-> How to set up a development environment
-> How to run the Metabase Server
-> How to contribute back to the Metabase project
+> * How to compile your own copy of Metabase
+> * How to set up a development environment
+> * How to run the Metabase Server
+> * How to contribute back to the Metabase project
 
 
 # Contributing


### PR DESCRIPTION
GitHub's Markdown processor doesn't convert a newline character to an actual line break in a block quote, unless it's followed by two spaces. I figured this could just as well be a list.
